### PR TITLE
Implements UpdateElements

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,4 +196,4 @@ Please see our [contributing document](/CONTRIBUTING.md) if you would like to pa
 
 ### Authors
 
-`firewall_toolkit` is designed, authored, reviewed and supported by the members of ngrok's network edge team, including [@joewilliams](https://github.com/joewilliams).
+`firewall_toolkit` is designed, authored, reviewed and supported by the members of ngrok's network edge team, including [@joewilliams](https://github.com/joewilliams) and [@masonj188](https://github.com/masonj188).

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -55,17 +55,16 @@ func (s *ManagedSet) Start() {
 			case <-done:
 				return
 			case <-ticker.C:
-				flush := true
-
 				data, err := s.setUpdateFunc()
 				if err != nil {
 					s.logger.Errorf("error with set update function for table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
-					flush = false
+					continue
 				}
 
-				if err := s.Set.ClearAndAddElements(s.Conn, data); err != nil {
+				flush, err := s.Set.UpdateElements(s.Conn, data)
+				if err != nil {
 					s.logger.Errorf("error updating table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
-					flush = false
+					continue
 				}
 
 				// only flush if things went well above


### PR DESCRIPTION
Implements UpdateElements, which allows sets to be modified without clearing the previous set and applying the new one.

Previously, each time you wanted to update the values in a set, you had to use `ClearAndAddElements` which completely cleared the previous set and then added the new values to the clean set.

This PR calculates which items need to be added or removed from the existing set without deleting the existing unmodified rules.

