### PR TITLE
Refactor rule api and a few fixes/typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a collection of golang libraries and tools for managing nftables. It pro
 * `pkg/expressions` includes nftables expression partials for generating common firewall rules.
 * `pkg/xtables` library for bpf/ebpf nftables rule creation. It supports adding all three types of xtables bpf match configurations: bytecode, pinned bpf programs and socket file descriptors.
 * `pkg/set` is a library for managing nftables sets, it supports IPv4, IPv6 and port based set types.
+* `pkg/rule` is a library for managing nftable rules, it uses rule "user data" to provide unique IDs for each rule in a given chain.
 * `pkg/logger` supports the stdlib log and [zerolog](https://github.com/rs/zerolog), or bring your own logger.
 * `pkg/utils` utility functions for validating IPs and etc.
 * `cmd/*` provides tools you can use to manage nftables built on top of the firewall_toolkit, also serves as an example of how to use the library.

--- a/cmd/fwtk-input-filter-bpf/fwtk-input-filter-bpf.go
+++ b/cmd/fwtk-input-filter-bpf/fwtk-input-filter-bpf.go
@@ -85,8 +85,9 @@ func main() {
 		logger.Default.Fatal(err)
 	}
 
+	ruleTarget := rule.NewRuleTarget(nfTable, nfChain)
 	bpfRule := rule.NewRuleData([]byte{0xd, 0xe, 0xa, 0xd}, expressions.MatchBpfWithVerdict(xtBpfInfoBytes, nfVerdict))
-	added, err := rule.Add(c, nfTable, nfChain, bpfRule)
+	added, err := ruleTarget.Add(c, bpfRule)
 	if err != nil {
 		logger.Default.Fatalf("adding rule %x failed: %v", bpfRule.ID, err)
 	}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -11,9 +11,23 @@ import (
 	"github.com/google/nftables"
 )
 
+// RuleTarget represents a location to manipulate nftables rules
+type RuleTarget struct {
+	Table *nftables.Table
+	Chain *nftables.Chain
+}
+
+// Create a new location to manipulate nftables rules
+func NewRuleTarget(table *nftables.Table, chain *nftables.Chain) RuleTarget {
+	return RuleTarget{
+		Table: table,
+		Chain: chain,
+	}
+}
+
 // Add a rule with a given ID to a specific table and chain, returns true if the rule was added
-func Add(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, ruleData RuleData) (bool, error) {
-	exists, err := Exists(c, table, chain, ruleData)
+func (r *RuleTarget) Add(c *nftables.Conn, ruleData RuleData) (bool, error) {
+	exists, err := r.Exists(c, ruleData)
 	if err != nil {
 		return false, err
 	}
@@ -22,7 +36,7 @@ func Add(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, ruleDat
 		return false, nil
 	}
 
-	add(c, table, chain, ruleData)
+	add(c, r.Table, r.Chain, ruleData)
 	return true, nil
 }
 
@@ -36,8 +50,8 @@ func add(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, ruleDat
 }
 
 // Delete a rule with a given ID from a specific table and chain, returns true if the rule was deleted
-func Delete(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, ruleData RuleData) (bool, error) {
-	rules, err := c.GetRules(table, chain)
+func (r *RuleTarget) Delete(c *nftables.Conn, ruleData RuleData) (bool, error) {
+	rules, err := c.GetRules(r.Table, r.Chain)
 	if err != nil {
 		return false, err
 	}
@@ -57,8 +71,8 @@ func Delete(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, rule
 }
 
 // Determine if a rule with a given ID exists in a specific table and chain
-func Exists(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, ruleData RuleData) (bool, error) {
-	rules, err := c.GetRules(table, chain)
+func (r *RuleTarget) Exists(c *nftables.Conn, ruleData RuleData) (bool, error) {
+	rules, err := c.GetRules(r.Table, r.Chain)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -35,7 +35,7 @@ type Set struct {
 }
 
 // Create a new set on a table with a given key type
-func New(name string, c *nftables.Conn, table *nftables.Table, keyType nftables.SetDatatype) (Set, error) {
+func New(c *nftables.Conn, table *nftables.Table, name string, keyType nftables.SetDatatype) (Set, error) {
 	// we've seen problems where sets need to be initialized with a value otherwise nftables seems to default to the
 	// native endianness, likely little endian, which is always incorrect for network stuff resulting in backwards ips, etc.
 	// we set everything to documentation values and then immediately delete them leaving empty, correctly created sets.

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -20,14 +20,14 @@ type SetUpdateFunc func() ([]SetData, error)
 type ManagedSet struct {
 	WaitGroup     *sync.WaitGroup
 	Conn          *nftables.Conn
-	Set           *Set
+	Set           Set
 	setUpdateFunc SetUpdateFunc
 	interval      time.Duration
 	logger        logger.Logger
 }
 
 // Create a set manager
-func ManagerInit(wg *sync.WaitGroup, c *nftables.Conn, set *Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
+func ManagerInit(wg *sync.WaitGroup, c *nftables.Conn, set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
 	return ManagedSet{
 		WaitGroup:     wg,
 		Conn:          c,
@@ -40,7 +40,7 @@ func ManagerInit(wg *sync.WaitGroup, c *nftables.Conn, set *Set, f SetUpdateFunc
 
 // Start the set manager goroutine
 func (s *ManagedSet) Start() {
-	s.logger.Infof("starting set manager fortable/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
+	s.logger.Infof("starting set manager for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
 	defer s.WaitGroup.Done()
 
 	sigChan := make(chan os.Signal, 1)


### PR DESCRIPTION
This PR changes the rule API to a pointer receiver style using the new `RuleTarget` struct. It also includes a few typo fixes, set tests, readme updates and etc.