### PR TITLE
use error groups and supply managers with a context

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+linters-settings:
+  nestif:
+    min-complexity: 6

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -3,9 +3,9 @@
 package set
 
 import (
+	"context"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
@@ -18,7 +18,6 @@ type SetUpdateFunc func() ([]SetData, error)
 
 // Represents a set managed by the manager goroutine
 type ManagedSet struct {
-	WaitGroup     *sync.WaitGroup
 	Conn          *nftables.Conn
 	Set           Set
 	setUpdateFunc SetUpdateFunc
@@ -27,9 +26,8 @@ type ManagedSet struct {
 }
 
 // Create a set manager
-func ManagerInit(wg *sync.WaitGroup, c *nftables.Conn, set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
+func ManagerInit(c *nftables.Conn, set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
 	return ManagedSet{
-		WaitGroup:     wg,
 		Conn:          c,
 		Set:           set,
 		setUpdateFunc: f,
@@ -39,44 +37,40 @@ func ManagerInit(wg *sync.WaitGroup, c *nftables.Conn, set Set, f SetUpdateFunc,
 }
 
 // Start the set manager goroutine
-func (s *ManagedSet) Start() {
+func (s *ManagedSet) Start(ctx context.Context) error {
 	s.logger.Infof("starting set manager for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
-	defer s.WaitGroup.Done()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-
 	ticker := time.NewTicker(s.interval)
-	done := make(chan bool)
 
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				data, err := s.setUpdateFunc()
-				if err != nil {
-					s.logger.Errorf("error with set update function for table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
-					continue
-				}
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Infof("got context done, stopping set update loop for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
+			return nil
+		case sig := <-sigChan:
+			s.logger.Infof("got %s, stopping set update loop for table/set %v/%v", sig, s.Set.Set.Table.Name, s.Set.Set.Name)
+			return nil
+		case <-ticker.C:
+			data, err := s.setUpdateFunc()
+			if err != nil {
+				s.logger.Errorf("error with set update function for table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
+				continue
+			}
 
-				flush, err := s.Set.UpdateElements(s.Conn, data)
-				if err != nil {
-					s.logger.Errorf("error updating table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
-					continue
-				}
+			flush, err := s.Set.UpdateElements(s.Conn, data)
+			if err != nil {
+				s.logger.Errorf("error updating table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
+				continue
+			}
 
-				// only flush if things went well above
-				if flush {
-					if err := s.Conn.Flush(); err != nil {
-						s.logger.Errorf("error flushing table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
-					}
+			// only flush if things went well above
+			if flush {
+				if err := s.Conn.Flush(); err != nil {
+					s.logger.Errorf("error flushing table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
 				}
 			}
 		}
-	}()
-
-	<-sigChan
-	s.logger.Infof("got sigterm, stopping set update loop for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
+	}
 }


### PR DESCRIPTION
This PR changes managers to use an error group rather than wait group and supplies them with a context.