### PR TITLE
set and rule types should read-only-ish

### DIFF
--- a/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets.go
+++ b/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets.go
@@ -134,7 +134,7 @@ func main() {
 
 	ruleTarget := rule.NewRuleTarget(nfTable, nfChain)
 
-	ruleInfo := newRuleInfo(portSet, ipv4Set, ipv6Set)
+	ruleInfo := newRuleInfo(portSet.GetSet(), ipv4Set.GetSet(), ipv6Set.GetSet())
 
 	ruleData, err := ruleInfo.createRuleData()
 	if err != nil {
@@ -169,7 +169,6 @@ func main() {
 		defer cancel()
 
 		ipv4SetManager, err := set.ManagerInit(
-			c,
 			ipv4Set,
 			ipSource.getIPList,
 			RefreshInterval,
@@ -181,7 +180,6 @@ func main() {
 		}
 
 		ipv6SetManager, err := set.ManagerInit(
-			c,
 			ipv6Set,
 			ipSource.getIPList,
 			RefreshInterval,
@@ -193,7 +191,6 @@ func main() {
 		}
 
 		portSetManager, err := set.ManagerInit(
-			c,
 			portSet,
 			portSource.getPortList,
 			RefreshInterval,
@@ -205,7 +202,6 @@ func main() {
 		}
 
 		ruleManager, err := rule.ManagerInit(
-			c,
 			ruleTarget,
 			ruleInfo.createRuleData,
 			RefreshInterval,
@@ -301,12 +297,12 @@ func readFile(path string) ([]string, error) {
 }
 
 type ruleInfo struct {
-	PortSet set.Set
-	IPv4Set set.Set
-	IPv6Set set.Set
+	PortSet *nftables.Set
+	IPv4Set *nftables.Set
+	IPv6Set *nftables.Set
 }
 
-func newRuleInfo(portSet set.Set, ipv4Set set.Set, ipv6Set set.Set) ruleInfo {
+func newRuleInfo(portSet *nftables.Set, ipv4Set *nftables.Set, ipv6Set *nftables.Set) ruleInfo {
 	return ruleInfo{
 		PortSet: portSet,
 		IPv4Set: ipv4Set,
@@ -315,12 +311,12 @@ func newRuleInfo(portSet set.Set, ipv4Set set.Set, ipv6Set set.Set) ruleInfo {
 }
 
 func (s *ruleInfo) createRuleData() ([]rule.RuleData, error) {
-	ipv6Exprs, err := generateExpression(s.PortSet.Set, s.IPv6Set.Set)
+	ipv6Exprs, err := generateExpression(s.PortSet, s.IPv6Set)
 	if err != nil {
 		return []rule.RuleData{}, err
 	}
 
-	ipv4Exprs, err := generateExpression(s.PortSet.Set, s.IPv4Set.Set)
+	ipv4Exprs, err := generateExpression(s.PortSet, s.IPv4Set)
 	if err != nil {
 		return []rule.RuleData{}, err
 	}

--- a/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets_test.go
+++ b/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
-	"github.com/ngrok/firewall_toolkit/pkg/set"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,9 +63,9 @@ func TestGenerateIPv6Rule(t *testing.T) {
 }
 
 func TestCreateRuleData(t *testing.T) {
-	portSet := set.Set{Set: &nftables.Set{Name: "testportset", KeyType: nftables.TypeInetService}}
-	ipv4Set := set.Set{Set: &nftables.Set{Name: "testipv4set", KeyType: nftables.TypeIPAddr}}
-	ipv6Set := set.Set{Set: &nftables.Set{Name: "testipv6set", KeyType: nftables.TypeIP6Addr}}
+	portSet := &nftables.Set{Name: "testportset", KeyType: nftables.TypeInetService}
+	ipv4Set := &nftables.Set{Name: "testipv4set", KeyType: nftables.TypeIPAddr}
+	ipv6Set := &nftables.Set{Name: "testipv6set", KeyType: nftables.TypeIP6Addr}
 
 	ruleInfo := newRuleInfo(portSet, ipv4Set, ipv6Set)
 	ruleData, err := ruleInfo.createRuleData()

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -119,7 +119,7 @@ func (r *RuleTarget) Update(c *nftables.Conn, rules []RuleData) (bool, error) {
 }
 
 // Get the nftables table and chain associated with this RuleTarget
-func (r *RuleTarget) GetRuleTarget() (*nftables.Table, *nftables.Chain) {
+func (r *RuleTarget) GetTableAndChain() (*nftables.Table, *nftables.Chain) {
 	return r.table, r.chain
 }
 

--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -18,18 +18,23 @@ type RulesUpdateFunc func() ([]RuleData, error)
 
 // Represents a table/chain ruleset managed by the manager goroutine
 type ManagedRules struct {
-	Conn            *nftables.Conn
-	RuleTarget      RuleTarget
+	conn            *nftables.Conn
+	ruleTarget      RuleTarget
 	rulesUpdateFunc RulesUpdateFunc
 	interval        time.Duration
 	logger          logger.Logger
 }
 
 // Create a rule manager
-func ManagerInit(c *nftables.Conn, ruleTarget RuleTarget, f RulesUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedRules, error) {
+func ManagerInit(ruleTarget RuleTarget, f RulesUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedRules, error) {
+	c, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		return ManagedRules{}, err
+	}
+
 	return ManagedRules{
-		Conn:            c,
-		RuleTarget:      ruleTarget,
+		conn:            c,
+		ruleTarget:      ruleTarget,
 		rulesUpdateFunc: f,
 		interval:        interval,
 		logger:          logger,
@@ -38,7 +43,7 @@ func ManagerInit(c *nftables.Conn, ruleTarget RuleTarget, f RulesUpdateFunc, int
 
 // Start the rule manager goroutine
 func (r *ManagedRules) Start(ctx context.Context) error {
-	r.logger.Infof("starting rule manager for table/chain %v/%v", r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name)
+	r.logger.Infof("starting rule manager for table/chain %v/%v", r.ruleTarget.table.Name, r.ruleTarget.chain.Name)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
@@ -47,29 +52,34 @@ func (r *ManagedRules) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			r.logger.Infof("got context done, stopping rule update loop for table/chain %v/%v", r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name)
+			r.logger.Infof("got context done, stopping rule update loop for table/chain %v/%v", r.ruleTarget.table.Name, r.ruleTarget.chain.Name)
 			return nil
 		case sig := <-sigChan:
-			r.logger.Infof("got %s, stopping rule update loop for table/chain %v/%v", sig, r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name)
+			r.logger.Infof("got %s, stopping rule update loop for table/chain %v/%v", sig, r.ruleTarget.table.Name, r.ruleTarget.chain.Name)
 			return nil
 		case <-ticker.C:
 			ruleData, err := r.rulesUpdateFunc()
 			if err != nil {
-				r.logger.Errorf("error with rules update function for table/chain %v/%v: %v", r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name, err)
+				r.logger.Errorf("error with rules update function for table/chain %v/%v: %v", r.ruleTarget.table.Name, r.ruleTarget.chain.Name, err)
 			}
 
-			flush, err := r.RuleTarget.Update(r.Conn, ruleData)
+			flush, err := r.ruleTarget.Update(r.conn, ruleData)
 			if err != nil {
 				r.logger.Errorf("error updating rules: %v", err)
 			}
 
 			// only flush if things went well above
 			if flush {
-				r.logger.Infof("flushing rules for table/chain %v/%v", r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name)
-				if err := r.Conn.Flush(); err != nil {
-					r.logger.Errorf("error flushing rules for table/chain %v/%v: %v", r.RuleTarget.Table.Name, r.RuleTarget.Chain.Name, err)
+				r.logger.Infof("flushing rules for table/chain %v/%v", r.ruleTarget.table.Name, r.ruleTarget.chain.Name)
+				if err := r.conn.Flush(); err != nil {
+					r.logger.Errorf("error flushing rules for table/chain %v/%v: %v", r.ruleTarget.table.Name, r.ruleTarget.chain.Name, err)
 				}
 			}
 		}
 	}
+}
+
+// Get the rule target that this manager is operating on
+func (r *ManagedRules) GetRuleTarget() RuleTarget {
+	return r.ruleTarget
 }

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -133,3 +133,44 @@ func TestGenRuleDelta(t *testing.T) {
 	}
 
 }
+
+func TestGetRuleTarget(t *testing.T) {
+	table := &nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   "testtable",
+	}
+
+	chain := &nftables.Chain{
+		Table: table,
+		Name:  "testchain",
+	}
+
+	ruleTarget := NewRuleTarget(table, chain)
+
+	rtTable, rtChain := ruleTarget.GetTableAndChain()
+
+	assert.Equal(t, table, rtTable)
+	assert.Equal(t, chain, rtChain)
+}
+
+func TestManagerGetRuleTarget(t *testing.T) {
+	table := &nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   "testtable",
+	}
+
+	chain := &nftables.Chain{
+		Table: table,
+		Name:  "testchain",
+	}
+
+	mR := ManagedRules{
+		ruleTarget: NewRuleTarget(table, chain),
+	}
+
+	rt := mR.GetRuleTarget()
+	rtTable, rtChain := rt.GetTableAndChain()
+
+	assert.Equal(t, table, rtTable)
+	assert.Equal(t, chain, rtChain)
+}

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -18,18 +18,23 @@ type SetUpdateFunc func() ([]SetData, error)
 
 // Represents a set managed by the manager goroutine
 type ManagedSet struct {
-	Conn          *nftables.Conn
-	Set           Set
+	conn          *nftables.Conn
+	set           Set
 	setUpdateFunc SetUpdateFunc
 	interval      time.Duration
 	logger        logger.Logger
 }
 
 // Create a set manager
-func ManagerInit(c *nftables.Conn, set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
+func ManagerInit(set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
+	c, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		return ManagedSet{}, err
+	}
+
 	return ManagedSet{
-		Conn:          c,
-		Set:           set,
+		conn:          c,
+		set:           set,
 		setUpdateFunc: f,
 		interval:      interval,
 		logger:        logger,
@@ -38,7 +43,7 @@ func ManagerInit(c *nftables.Conn, set Set, f SetUpdateFunc, interval time.Durat
 
 // Start the set manager goroutine
 func (s *ManagedSet) Start(ctx context.Context) error {
-	s.logger.Infof("starting set manager for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
+	s.logger.Infof("starting set manager for table/set %v/%v", s.set.set.Table.Name, s.set.set.Name)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
@@ -47,30 +52,35 @@ func (s *ManagedSet) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			s.logger.Infof("got context done, stopping set update loop for table/set %v/%v", s.Set.Set.Table.Name, s.Set.Set.Name)
+			s.logger.Infof("got context done, stopping set update loop for table/set %v/%v", s.set.set.Table.Name, s.set.set.Name)
 			return nil
 		case sig := <-sigChan:
-			s.logger.Infof("got %s, stopping set update loop for table/set %v/%v", sig, s.Set.Set.Table.Name, s.Set.Set.Name)
+			s.logger.Infof("got %s, stopping set update loop for table/set %v/%v", sig, s.set.set.Table.Name, s.set.set.Name)
 			return nil
 		case <-ticker.C:
 			data, err := s.setUpdateFunc()
 			if err != nil {
-				s.logger.Errorf("error with set update function for table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
+				s.logger.Errorf("error with set update function for table/set %v/%v: %v", s.set.set.Table.Name, s.set.set.Name, err)
 				continue
 			}
 
-			flush, err := s.Set.UpdateElements(s.Conn, data)
+			flush, err := s.set.UpdateElements(s.conn, data)
 			if err != nil {
-				s.logger.Errorf("error updating table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
+				s.logger.Errorf("error updating table/set %v/%v: %v", s.set.set.Table.Name, s.set.set.Name, err)
 				continue
 			}
 
 			// only flush if things went well above
 			if flush {
-				if err := s.Conn.Flush(); err != nil {
-					s.logger.Errorf("error flushing table/set %v/%v: %v", s.Set.Set.Table.Name, s.Set.Set.Name, err)
+				if err := s.conn.Flush(); err != nil {
+					s.logger.Errorf("error flushing table/set %v/%v: %v", s.set.set.Table.Name, s.set.set.Name, err)
 				}
 			}
 		}
 	}
+}
+
+// Get the set this manager is operating on
+func (s *ManagedSet) GetSet() Set {
+	return s.set
 }

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -584,3 +584,37 @@ func TestUpdateElements(t *testing.T) {
 	assert.Nil(t, err)
 	c.Flush()
 }
+
+func TestGetSet(t *testing.T) {
+	nfSet := &nftables.Set{
+		Name:     "testset",
+		Table:    &nftables.Table{},
+		KeyType:  nftables.TypeIPAddr,
+		Interval: true,
+		Counter:  true,
+	}
+
+	set := Set{set: nfSet}
+
+	assert.Equal(t, nfSet, set.GetSet())
+}
+
+func TestManagerGetSet(t *testing.T) {
+	nfSet := &nftables.Set{
+		Name:     "testset",
+		Table:    &nftables.Table{},
+		KeyType:  nftables.TypeIPAddr,
+		Interval: true,
+		Counter:  true,
+	}
+
+	set := Set{set: nfSet}
+
+	mS := ManagedSet{
+		set: set,
+	}
+
+	mSet := mS.GetSet()
+
+	assert.Equal(t, nfSet, mSet.GetSet())
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -70,11 +70,11 @@ func TestNewV4Set(t *testing.T) {
 	res, err := New(c, table, "testset", nftables.TypeIPAddr)
 	assert.Nil(t, err)
 
-	assert.True(t, res.Set.Counter)
-	assert.True(t, res.Set.Interval)
-	assert.Equal(t, "testset", res.Set.Name)
-	assert.Equal(t, "testtable", res.Set.Table.Name)
-	assert.Equal(t, nftables.TypeIPAddr, res.Set.KeyType)
+	assert.True(t, res.set.Counter)
+	assert.True(t, res.set.Interval)
+	assert.Equal(t, "testset", res.set.Name)
+	assert.Equal(t, "testtable", res.set.Table.Name)
+	assert.Equal(t, nftables.TypeIPAddr, res.set.KeyType)
 	c.Flush()
 }
 
@@ -111,11 +111,11 @@ func TestNewV6Set(t *testing.T) {
 	res, err := New(c, table, "testset", nftables.TypeIP6Addr)
 	assert.Nil(t, err)
 
-	assert.True(t, res.Set.Counter)
-	assert.True(t, res.Set.Interval)
-	assert.Equal(t, "testset", res.Set.Name)
-	assert.Equal(t, "testtable", res.Set.Table.Name)
-	assert.Equal(t, nftables.TypeIP6Addr, res.Set.KeyType)
+	assert.True(t, res.set.Counter)
+	assert.True(t, res.set.Interval)
+	assert.Equal(t, "testset", res.set.Name)
+	assert.Equal(t, "testtable", res.set.Table.Name)
+	assert.Equal(t, nftables.TypeIP6Addr, res.set.KeyType)
 	c.Flush()
 }
 
@@ -152,11 +152,11 @@ func TestNewPortSet(t *testing.T) {
 	res, err := New(c, table, "testset", nftables.TypeInetService)
 	assert.Nil(t, err)
 
-	assert.True(t, res.Set.Counter)
-	assert.True(t, res.Set.Interval)
-	assert.Equal(t, "testset", res.Set.Name)
-	assert.Equal(t, "testtable", res.Set.Table.Name)
-	assert.Equal(t, nftables.TypeInetService, res.Set.KeyType)
+	assert.True(t, res.set.Counter)
+	assert.True(t, res.set.Interval)
+	assert.Equal(t, "testset", res.set.Name)
+	assert.Equal(t, "testtable", res.set.Table.Name)
+	assert.Equal(t, nftables.TypeInetService, res.set.KeyType)
 	c.Flush()
 }
 
@@ -188,7 +188,7 @@ func TestClearAndAddElements(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{Set: nfSet}
+	set := Set{set: nfSet}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)
@@ -221,7 +221,7 @@ func TestUpdateSetBadType(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{Set: nfSet}
+	set := Set{set: nfSet}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)
@@ -538,7 +538,7 @@ func TestRuleDataDelta(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		set := Set{CurrentSetData: test.current}
+		set := Set{currentSetData: test.current}
 		add, remove := set.genSetDataDelta(test.incoming)
 
 		assert.ElementsMatch(t, add, test.wantAdd)
@@ -575,7 +575,7 @@ func TestUpdateElements(t *testing.T) {
 		Counter:  true,
 	}
 	oldSetData, _ := AddressStringToSetData("192.0.2.0")
-	set := Set{Set: nfSet, Mu: &sync.Mutex{}, CurrentSetData: map[SetData]struct{}{oldSetData: {}}}
+	set := Set{set: nfSet, mu: &sync.Mutex{}, currentSetData: map[SetData]struct{}{oldSetData: {}}}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)


### PR DESCRIPTION
This PR changes:
* set and ruletarget types to be effectively read-only via get functions.
* manager types are are also read-only
* isolated "lasting" connections to netlink for each manager

The rationale here is that the internal state of fwtk objects should be fairly opaque to library users, only exposing the underlying google/nftables objects that they operate on via `get` functions. For instance it should not be possible to mess with the table a manager is working on, that said you might want to know which table that is so we provide a get function to do that. Similarly `Set` and `RuleTarget` types should not be able to change out from under you, nor should the mutex and etc be exposed to anyone, so they are private as well. Since `nftables.Set` objects are needed to build expressions that use them they are also available via get functions.

The rule-of-thumb going forward is fwtk exposes the underlying google/nftables objects via getters but no other internal state.