### PR TITLE
basically everything should be uints

### DIFF
--- a/cmd/fwtk-input-filter-bpf/fwtk-input-filter-bpf.go
+++ b/cmd/fwtk-input-filter-bpf/fwtk-input-filter-bpf.go
@@ -115,9 +115,9 @@ func getVerdict(verdict string) (*expr.Verdict, error) {
 }
 
 func getXtBpfInfoBytes(filter string) ([]byte, error) {
-	fd, err := strconv.Atoi(filter)
+	fd, err := strconv.ParseInt(filter, 10, 32)
 	if err == nil {
-		xtBpfInfoBytes, err := xtables.MarshalBpfFd(fd)
+		xtBpfInfoBytes, err := xtables.MarshalBpfFd(int32(fd))
 
 		if err != nil {
 			return []byte{}, err

--- a/pkg/expressions/partials.go
+++ b/pkg/expressions/partials.go
@@ -46,9 +46,9 @@ const (
 )
 
 // Returns a source port payload expression
-func SourcePort(reg int) *expr.Payload {
+func SourcePort(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseTransportHeader,
 		Offset:       SrcPortOffset,
 		Len:          PortLen,
@@ -56,9 +56,9 @@ func SourcePort(reg int) *expr.Payload {
 }
 
 // Returns a destination port payload expression
-func DestinationPort(reg int) *expr.Payload {
+func DestinationPort(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseTransportHeader,
 		Offset:       DstPortOffset,
 		Len:          PortLen,
@@ -66,9 +66,9 @@ func DestinationPort(reg int) *expr.Payload {
 }
 
 // Returns a IPv4 source address payload expression
-func IPv4SourceAddress(reg int) *expr.Payload {
+func IPv4SourceAddress(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseNetworkHeader,
 		Offset:       IPv4SrcOffset,
 		Len:          IPv4AddrLen,
@@ -76,9 +76,9 @@ func IPv4SourceAddress(reg int) *expr.Payload {
 }
 
 // Returns a IPv6 source address payload expression
-func IPv6SourceAddress(reg int) *expr.Payload {
+func IPv6SourceAddress(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseNetworkHeader,
 		Offset:       IPv6SrcOffest,
 		Len:          IPv6AddrLen,
@@ -86,9 +86,9 @@ func IPv6SourceAddress(reg int) *expr.Payload {
 }
 
 // Returns a IPv4 destination address payload expression
-func IPv4DestinationAddress(reg int) *expr.Payload {
+func IPv4DestinationAddress(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseNetworkHeader,
 		Offset:       IPv4DstOffset,
 		Len:          IPv4AddrLen,
@@ -96,9 +96,9 @@ func IPv4DestinationAddress(reg int) *expr.Payload {
 }
 
 // Returns a IPv6 destination address payload expression
-func IPv6DestinationAddress(reg int) *expr.Payload {
+func IPv6DestinationAddress(reg uint32) *expr.Payload {
 	return &expr.Payload{
-		DestRegister: uint32(reg),
+		DestRegister: reg,
 		Base:         expr.PayloadBaseNetworkHeader,
 		Offset:       IPv6DstOffset,
 		Len:          IPv6AddrLen,
@@ -106,28 +106,28 @@ func IPv6DestinationAddress(reg int) *expr.Payload {
 }
 
 // Returns a port set lookup expression
-func PortSetLookUp(set *nftables.Set, reg int) *expr.Lookup {
+func PortSetLookUp(set *nftables.Set, reg uint32) *expr.Lookup {
 	return &expr.Lookup{
-		SourceRegister: uint32(reg),
+		SourceRegister: reg,
 		SetName:        set.Name,
 		SetID:          set.ID,
 	}
 }
 
 // Returns an IP set lookup expression
-func IPSetLookUp(set *nftables.Set, reg int) *expr.Lookup {
+func IPSetLookUp(set *nftables.Set, reg uint32) *expr.Lookup {
 	return &expr.Lookup{
-		SourceRegister: uint32(reg),
+		SourceRegister: reg,
 		SetName:        set.Name,
 		SetID:          set.ID,
 	}
 }
 
 // Returns a meta expression
-func Meta(meta expr.MetaKey, reg int) *expr.Meta {
+func Meta(meta expr.MetaKey, reg uint32) *expr.Meta {
 	return &expr.Meta{
 		Key:      meta,
-		Register: uint32(reg),
+		Register: reg,
 	}
 }
 
@@ -137,10 +137,10 @@ func Counter() *expr.Counter {
 }
 
 // Returns an equal comparison expression
-func Equals(data []byte, reg int) *expr.Cmp {
+func Equals(data []byte, reg uint32) *expr.Cmp {
 	return &expr.Cmp{
 		Op:       expr.CmpOpEq,
-		Register: uint32(reg),
+		Register: reg,
 		Data:     data,
 	}
 }
@@ -160,16 +160,16 @@ func Drop() *expr.Verdict {
 }
 
 // Returns a xtables match expression
-func Match(name string, revision int, info xt.InfoAny) *expr.Match {
+func Match(name string, revision uint32, info xt.InfoAny) *expr.Match {
 	return &expr.Match{
 		Name: name,
-		Rev:  uint32(revision),
+		Rev:  revision,
 		Info: info,
 	}
 }
 
 // Returns a xtables match expression of unknown type
-func MatchUnknown(name string, revision int, info []byte) *expr.Match {
+func MatchUnknown(name string, revision uint32, info []byte) *expr.Match {
 	infoBytes := xt.Unknown(info)
 	return Match(name, revision, &infoBytes)
 }
@@ -193,7 +193,7 @@ func CompareProtocolFamily(proto byte) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the protocol family of traffic, with a user defined register
-func CompareProtocolFamilyWithRegister(proto byte, reg int) ([]expr.Any, error) {
+func CompareProtocolFamilyWithRegister(proto byte, reg uint32) ([]expr.Any, error) {
 	if int(proto) >= unix.NFPROTO_NUMPROTO {
 		return []expr.Any{}, fmt.Errorf("invalid protocol family %v", proto)
 	}
@@ -211,7 +211,7 @@ func CompareTransportProtocol(proto byte) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the transport protocol of traffic, with a user defined register
-func CompareTransportProtocolWithRegister(proto byte, reg int) ([]expr.Any, error) {
+func CompareTransportProtocolWithRegister(proto byte, reg uint32) ([]expr.Any, error) {
 	// it seems like netlink and/or nftables assume proto is unint8 but it can be larger
 	// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/in.h#L83
 	// we use byte here to work around this and support everything but MPTCP
@@ -225,36 +225,36 @@ func CompareTransportProtocolWithRegister(proto byte, reg int) ([]expr.Any, erro
 }
 
 // Returns a list of expressions that will compare the source port of traffic
-func CompareSourcePort(port int) ([]expr.Any, error) {
+func CompareSourcePort(port uint16) ([]expr.Any, error) {
 	return CompareSourcePortWithRegister(port, defaultRegister)
 }
 
 // Returns a list of expressions that will compare the source port of traffic, with a user defined register
-func CompareSourcePortWithRegister(port int, reg int) ([]expr.Any, error) {
+func CompareSourcePortWithRegister(port uint16, reg uint32) ([]expr.Any, error) {
 	if err := utils.ValidatePort(port); err != nil {
 		return []expr.Any{}, err
 	}
 
 	return []expr.Any{
 		SourcePort(reg),
-		Equals(binaryutil.BigEndian.PutUint16(uint16(port)), reg),
+		Equals(binaryutil.BigEndian.PutUint16(port), reg),
 	}, nil
 }
 
 // Returns a list of expressions that will compare the destination port of traffic
-func CompareDestinationPort(port int) ([]expr.Any, error) {
+func CompareDestinationPort(port uint16) ([]expr.Any, error) {
 	return CompareDestinationPortWithRegister(port, defaultRegister)
 }
 
 // Returns a list of expressions that will compare the destination port of traffic, with a user defined register
-func CompareDestinationPortWithRegister(port int, reg int) ([]expr.Any, error) {
+func CompareDestinationPortWithRegister(port uint16, reg uint32) ([]expr.Any, error) {
 	if err := utils.ValidatePort(port); err != nil {
 		return []expr.Any{}, err
 	}
 
 	return []expr.Any{
 		DestinationPort(reg),
-		Equals(binaryutil.BigEndian.PutUint16(uint16(port)), reg),
+		Equals(binaryutil.BigEndian.PutUint16(port), reg),
 	}, nil
 }
 
@@ -264,7 +264,7 @@ func CompareSourceAddress(ip netip.Addr) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the source address of traffic, with a user defined register
-func CompareSourceAddressWithRegister(ip netip.Addr, reg int) ([]expr.Any, error) {
+func CompareSourceAddressWithRegister(ip netip.Addr, reg uint32) ([]expr.Any, error) {
 	if err := utils.ValidateAddress(ip); err != nil {
 		return []expr.Any{}, err
 	}
@@ -290,7 +290,7 @@ func CompareDestinationAddress(ip netip.Addr) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the destination address of traffic, with a user defined register
-func CompareDestinationAddressWithRegister(ip netip.Addr, reg int) ([]expr.Any, error) {
+func CompareDestinationAddressWithRegister(ip netip.Addr, reg uint32) ([]expr.Any, error) {
 	if err := utils.ValidateAddress(ip); err != nil {
 		return []expr.Any{}, err
 	}
@@ -316,7 +316,7 @@ func CompareSourceAddressSet(set *nftables.Set) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the source address of traffic against a set, with a user defined register
-func CompareSourceAddressSetWithRegister(set *nftables.Set, reg int) ([]expr.Any, error) {
+func CompareSourceAddressSetWithRegister(set *nftables.Set, reg uint32) ([]expr.Any, error) {
 	var srcAddr *expr.Payload
 	switch set.KeyType {
 	case nftables.TypeIPAddr:
@@ -336,7 +336,7 @@ func CompareDestinationAddressSet(set *nftables.Set) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the destnation address of traffic against a set, with a user defined register
-func CompareDestinationAddressSetWithRegister(set *nftables.Set, reg int) ([]expr.Any, error) {
+func CompareDestinationAddressSetWithRegister(set *nftables.Set, reg uint32) ([]expr.Any, error) {
 	var dstAddr *expr.Payload
 	switch set.KeyType {
 	case nftables.TypeIPAddr:
@@ -356,7 +356,7 @@ func CompareSourcePortSet(set *nftables.Set) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the source port of traffic against a set, with a user defined register
-func CompareSourcePortSetWithRegister(set *nftables.Set, reg int) ([]expr.Any, error) {
+func CompareSourcePortSetWithRegister(set *nftables.Set, reg uint32) ([]expr.Any, error) {
 	return []expr.Any{SourcePort(reg), PortSetLookUp(set, reg)}, nil
 }
 
@@ -366,6 +366,6 @@ func CompareDestinationPortSet(set *nftables.Set) ([]expr.Any, error) {
 }
 
 // Returns a list of expressions that will compare the destination port of traffic against a set, with a user defined register
-func CompareDestinationPortSetWithRegister(set *nftables.Set, reg int) ([]expr.Any, error) {
+func CompareDestinationPortSetWithRegister(set *nftables.Set, reg uint32) ([]expr.Any, error) {
 	return []expr.Any{DestinationPort(reg), PortSetLookUp(set, reg)}, nil
 }

--- a/pkg/expressions/partials_test.go
+++ b/pkg/expressions/partials_test.go
@@ -157,16 +157,6 @@ func TestMatchBpfWithVerdict(t *testing.T) {
 	assert.Equal(t, &expr.Verdict{Kind: expr.VerdictDrop}, match[1])
 }
 
-func TestCompareBadPort(t *testing.T) {
-	res, err := CompareSourcePort(10000000)
-	assert.Error(t, err)
-	assert.Equal(t, []expr.Any{}, res)
-
-	res, err = CompareDestinationPort(10000000)
-	assert.Error(t, err)
-	assert.Equal(t, []expr.Any{}, res)
-}
-
 func TestCompareBadAddress(t *testing.T) {
 	res, err := CompareSourceAddress(netip.Addr{})
 	assert.Error(t, err)

--- a/pkg/set/set_data.go
+++ b/pkg/set/set_data.go
@@ -10,9 +10,9 @@ import (
 
 // SetData is a struct that is used to create elements of a given set based on the key type of the set
 type SetData struct {
-	Port              int
-	PortRangeStart    int
-	PortRangeEnd      int
+	Port              uint16
+	PortRangeStart    uint16
+	PortRangeEnd      uint16
 	Address           netip.Addr
 	AddressRangeStart netip.Addr
 	AddressRangeEnd   netip.Addr
@@ -95,29 +95,29 @@ func AddressStringsToSetData(addressStrings []string) ([]SetData, error) {
 
 // Convert a string port to the SetData type
 func PortStringToSetData(portString string) (SetData, error) {
-	port, err := strconv.Atoi(portString)
+	port, err := strconv.ParseUint(portString, 10, 16)
 	if err != nil {
 		return SetData{}, err
 	}
 
-	return SetData{Port: port}, nil
+	return SetData{Port: uint16(port)}, nil
 }
 
 // Convert a string port range to the SetData type
 func PortRangeStringToSetData(startString string, endString string) (SetData, error) {
-	start, err := strconv.Atoi(startString)
+	start, err := strconv.ParseUint(startString, 10, 16)
 	if err != nil {
 		return SetData{}, err
 	}
 
-	end, err := strconv.Atoi(endString)
+	end, err := strconv.ParseUint(endString, 10, 16)
 	if err != nil {
 		return SetData{}, err
 	}
 
 	return SetData{
-		PortRangeStart: start,
-		PortRangeEnd:   end,
+		PortRangeStart: uint16(start),
+		PortRangeEnd:   uint16(end),
 	}, nil
 }
 
@@ -258,5 +258,5 @@ func NetipAddrPortsToSetData(addrports []netip.AddrPort) ([]SetData, []SetData, 
 
 // Convert netip.AddrPort to SetData type, returns a address and a port
 func NetipAddrPortToSetData(addrport netip.AddrPort) (SetData, SetData, error) {
-	return SetData{Address: addrport.Addr()}, SetData{Port: int(addrport.Port())}, nil
+	return SetData{Address: addrport.Addr()}, SetData{Port: uint16(addrport.Port())}, nil
 }

--- a/pkg/set/set_data_test.go
+++ b/pkg/set/set_data_test.go
@@ -3,7 +3,6 @@ package set
 import (
 	"net"
 	"net/netip"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -225,10 +224,7 @@ func TestGoodPort(t *testing.T) {
 	res, err := PortStringToSetData(one)
 	assert.Nil(t, err)
 
-	parsed, err := strconv.Atoi(one)
-	assert.Nil(t, err)
-
-	assert.Equal(t, res.Port, parsed)
+	assert.Equal(t, res.Port, uint16(8000))
 }
 
 func TestGoodPortRange(t *testing.T) {
@@ -237,14 +233,8 @@ func TestGoodPortRange(t *testing.T) {
 	res, err := PortRangeStringToSetData(one, two)
 	assert.Nil(t, err)
 
-	parsedOne, err := strconv.Atoi(one)
-	assert.Nil(t, err)
-
-	parsedTwo, err := strconv.Atoi(two)
-	assert.Nil(t, err)
-
-	assert.Equal(t, res.PortRangeStart, parsedOne)
-	assert.Equal(t, res.PortRangeEnd, parsedTwo)
+	assert.Equal(t, res.PortRangeStart, uint16(8000))
+	assert.Equal(t, res.PortRangeEnd, uint16(9000))
 }
 
 func TestGoodNetipAddressesV4(t *testing.T) {
@@ -272,5 +262,5 @@ func TestGoodNetipAddrPortsV4(t *testing.T) {
 	addrs, ports, err := NetipAddrPortsToSetData(list)
 	assert.Nil(t, err)
 	assert.Equal(t, addrs[0].Address, parsed.Addr())
-	assert.Equal(t, ports[0].Port, int(parsed.Port()))
+	assert.Equal(t, ports[0].Port, parsed.Port())
 }

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -353,24 +353,6 @@ func TestGenerateSetElementsInvalidPrefixV6(t *testing.T) {
 	assert.Equal(t, []nftables.SetElement{}, res)
 }
 
-func TestGenerateSetElementsInvalidPort(t *testing.T) {
-	setData := []SetData{
-		{Port: -1000},
-	}
-	res, err := generateElements(nftables.TypeInetService, setData)
-	assert.Error(t, err)
-	assert.Equal(t, []nftables.SetElement{}, res)
-}
-
-func TestGenerateSetElementsInvalidPortRange(t *testing.T) {
-	setData := []SetData{
-		{PortRangeStart: 100000, PortRangeEnd: 1000001},
-	}
-	res, err := generateElements(nftables.TypeInetService, setData)
-	assert.Error(t, err)
-	assert.Equal(t, []nftables.SetElement{}, res)
-}
-
 func TestGenerateSetElementsEmptySetDataPorts(t *testing.T) {
 	setData := []SetData{{}}
 	res, err := generateElements(nftables.TypeInetService, setData)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Validates start and end port numbers
-func ValidatePortRange(start int, end int) error {
+func ValidatePortRange(start uint16, end uint16) error {
 	if err := ValidatePort(start); err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func ValidatePortRange(start int, end int) error {
 }
 
 // Validates a port number
-func ValidatePort(port int) error {
+func ValidatePort(port uint16) error {
 	if port < 1 {
 		return fmt.Errorf("port (%v) less than 1", port)
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -12,16 +12,6 @@ func TestValidatePortRange(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestValidateBadPortRangeStart(t *testing.T) {
-	err := ValidatePortRange(-100, 100)
-	assert.Error(t, err)
-}
-
-func TestValidateBadPortRangeEnd(t *testing.T) {
-	err := ValidatePortRange(100, -100)
-	assert.Error(t, err)
-}
-
 func TestValidateBadPortRangeBeginEnd(t *testing.T) {
 	err := ValidatePortRange(101, 100)
 	assert.Error(t, err)
@@ -34,11 +24,6 @@ func TestValidatePort(t *testing.T) {
 
 func TestValidateBadPortLow(t *testing.T) {
 	err := ValidatePort(0)
-	assert.Error(t, err)
-}
-
-func TestValidateBadPortHight(t *testing.T) {
-	err := ValidatePort(10000000)
 	assert.Error(t, err)
 }
 

--- a/pkg/xtables/xtables.go
+++ b/pkg/xtables/xtables.go
@@ -49,8 +49,8 @@ const (
 )
 
 type bpfInfoV1 struct {
-	mode    int
-	fd      int
+	mode    uint16
+	fd      int32
 	program []bpf.RawInstruction
 	path    string
 }
@@ -97,7 +97,7 @@ func MarshalBpfBytecode(filter string) ([]byte, error) {
 }
 
 // Marshal a socket file descriptor into bytes compatible with xtables
-func MarshalBpfFd(fd int) ([]byte, error) {
+func MarshalBpfFd(fd int32) ([]byte, error) {
 	if fd < 0 {
 		return []byte{}, fmt.Errorf("bad bpf file descriptor %v", fd)
 	}
@@ -136,13 +136,13 @@ func marshallBpfInfoV1(xtBpfInfo bpfInfoV1) ([]byte, error) {
 	}
 
 	// __u16 mode;
-	data.PutUint16(uint16(xtBpfInfo.mode))
+	data.PutUint16(xtBpfInfo.mode)
 
 	// __u16 bpf_program_num_elem;
 	data.PutUint16(uint16(len(xtBpfInfo.program)))
 
 	// __s32 fd;
-	data.PutInt32(int32(xtBpfInfo.fd))
+	data.PutInt32(xtBpfInfo.fd)
 
 	switch xtBpfInfo.mode {
 	case xtBpfModeBytecode:


### PR DESCRIPTION
All the tests pass:
```
go test -mod=vendor -race -cover -coverprofile=coverage.out ./...
?   	github.com/ngrok/firewall_toolkit	[no test files]
ok  	github.com/ngrok/firewall_toolkit/cmd/fwtk-input-filter-bpf	0.061s	coverage: 29.6% of statements
ok  	github.com/ngrok/firewall_toolkit/cmd/fwtk-input-filter-sets	0.034s	coverage: 18.8% of statements
ok  	github.com/ngrok/firewall_toolkit/pkg/expressions	0.037s	coverage: 94.0% of statements
?   	github.com/ngrok/firewall_toolkit/pkg/logger	[no test files]
ok  	github.com/ngrok/firewall_toolkit/pkg/rule	0.036s	coverage: 23.2% of statements
ok  	github.com/ngrok/firewall_toolkit/pkg/set	0.035s	coverage: 83.9% of statements
ok  	github.com/ngrok/firewall_toolkit/pkg/utils	0.046s	coverage: 88.9% of statements
ok  	github.com/ngrok/firewall_toolkit/pkg/xtables	0.058s	coverage: 92.5% of statements
docker run --cap-add NET_ADMIN firewall_toolkit:a675682 make compat-test
CGO_ENABLED=0 go install -mod=vendor -v ./cmd/fwtk-input-filter-sets
go install -mod=vendor -v ./cmd/fwtk-input-filter-bpf
bash tests/compat-sets.sh
test: [compat-sets] create tables, chain and sets ...                                           OK (0s)
test: [compat-sets] rules should already exist ...                                              OK (0s)
test: [compat-sets] validate nft output: hook ...                                               OK (0s)
test: [compat-sets] validate nft output: priority ...                                           OK (0s)
test: [compat-sets] validate nft output: rule protocol ip ...                                   OK (1s)
test: [compat-sets] validate nft output: rule protocol ipv6 ...                                 OK (0s)
test: [compat-sets] validate nft output: rule saddr field ...                                   OK (0s)
test: [compat-sets] validate nft output: rule transport protocol field ...                      OK (0s)
test: [compat-sets] validate nft output: rule dport field ...                                   OK (0s)
test: [compat-sets] validate nft output: rule drop verdict ...                                  OK (0s)
test: [compat-sets] validate nft output: set flags ...                                          OK (0s)
test: [compat-sets] validate nft output: ipv4 set ...                                           OK (0s)
test: [compat-sets] validate nft output: ipv4 set content (single ip) ...                       OK (0s)
test: [compat-sets] validate nft output: ipv4 set content (range start) ...                     OK (0s)
test: [compat-sets] validate nft output: ipv4 set content (range end) ...                       OK (0s)
test: [compat-sets] validate nft output: ipv4 set content (cidr address) ...                    OK (0s)
test: [compat-sets] validate nft output: ipv4 set content (cidr mask) ...                       OK (0s)
test: [compat-sets] validate nft output: ipv6 set ...                                           OK (0s)
test: [compat-sets] validate nft output: ipv6 set content (single ip) ...                       OK (0s)
test: [compat-sets] validate nft output: ipv6 set content (range start) ...                     OK (0s)
test: [compat-sets] validate nft output: ipv6 set content (range end) ...                       OK (0s)
test: [compat-sets] validate nft output: ipv6 set content (cidr address) ...                    OK (0s)
test: [compat-sets] validate nft output: ipv6 set content (cidr mask) ...                       OK (0s)
test: [compat-sets] validate nft output: port set ...                                           OK (0s)
test: [compat-sets] validate nft output: port set content (single port) ...                     OK (0s)
test: [compat-sets] validate nft output: port set content (port range start small) ...          OK (0s)
test: [compat-sets] validate nft output: port set content (port range end small) ...            OK (0s)
test: [compat-sets] validate nft output: port set content (port range start large) ...          OK (0s)
test: [compat-sets] validate nft output: port set content (port range end large) ...            OK (0s)
test: [compat-sets] delete table ...                                                            OK (0s)
bash tests/compat-bpf.sh
doesn't work inside docker, quitting
docker-compose -f tests/docker-compose.yml up -d fwtk-input-filter-sets-manager
Creating network "tests_integration" with the default driver
Creating tests_fwtk-input-filter-sets-manager_1 ... done
bash tests/integration-sets.sh
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 blocked ...                             FAILED (expected, 7s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 allowed ...                             OK (1s)
test: [integration-sets] replace port 8000 with 8001 ...                                             OK (0s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 blocked ...                             FAILED (expected, 4s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 allowed ...                             OK (1s)
test: [integration-sets] replace port 8001 with 8001-8002 ...                                        OK (0s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 blocked ...                             FAILED (expected, 4s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 blocked ...                             FAILED (expected, 4s)
test: [integration-sets] remove all ports from the list ...                                          OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 allowed ...                             OK (0s)
test: [integration-sets] add port 8000 back to the list ...                                          OK (1s)
test: [integration-sets] add ip range (172.200.1.101-172.200.1.105) to the list ...                  OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 blocked ...                             FAILED (expected, 4s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 allowed ...                             OK (0s)
test: [integration-sets] remove all ips from the list ...                                            OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8000 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8001 allowed ...                             OK (1s)
test: [integration-sets] 172.200.1.103 to 172.200.1.100:8002 allowed ...                             OK (1s)
```