### PR TITLE
dont use lasting netlink conns in the managers

### DIFF
--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -27,7 +27,7 @@ type ManagedRules struct {
 
 // Create a rule manager
 func ManagerInit(ruleTarget RuleTarget, f RulesUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedRules, error) {
-	c, err := nftables.New(nftables.AsLasting())
+	c, err := nftables.New()
 	if err != nil {
 		return ManagedRules{}, err
 	}

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -27,7 +27,7 @@ type ManagedSet struct {
 
 // Create a set manager
 func ManagerInit(set Set, f SetUpdateFunc, interval time.Duration, logger logger.Logger) (ManagedSet, error) {
-	c, err := nftables.New(nftables.AsLasting())
+	c, err := nftables.New()
 	if err != nil {
 		return ManagedSet{}, err
 	}


### PR DESCRIPTION
This PR turns off "lasting" connections to netlink inside the manager goroutines. The effect should be that each command is done over a new connection which should be fine. This was added in https://github.com/ngrok/firewall_toolkit/pull/7 as an optimization but it seems like it might be leading to errors.