### PR TITLE
added manager loop update data success metric

### DIFF
--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -92,6 +92,11 @@ func (r *ManagedRules) Start(ctx context.Context) error {
 					r.logger.Warnf("error sending manager_loop_update_data metric: %v", err)
 				}
 			}
+			err = r.metrics.Count(m.Prefix("manager_loop_update_data"), 1, r.genTags([]string{"success:true"}), 1)
+			if err != nil {
+				r.logger.Warnf("error sending manager_loop_update_data metric: %v", err)
+			}
+
 			// only flush if things went well above
 			if !flush {
 				continue

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -91,6 +91,11 @@ func (s *ManagedSet) Start(ctx context.Context) error {
 				}
 				continue
 			}
+			err = s.metrics.Count(m.Prefix("manager_loop_update_data"), 1, s.genTags([]string{"success:true"}), 1)
+			if err != nil {
+				s.logger.Warnf("error sending manager_loop_update_data metric: %v", err)
+			}
+
 			// only flush if things went well above
 			if !flush {
 				continue


### PR DESCRIPTION
Didn't include a "success" tagged count for the `manager_loop_update_data` metric, it was only sent on update failures.