### PR TITLE
Emit counter metrics tracking rule usage

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -158,6 +158,7 @@ func (r *RuleTarget) GetRuleUsageCounters(c *nftables.Conn) ([]RuleUsageCounter,
 			}
 
 			if compare, ok := ex.(*expr.Cmp); ok {
+				// The nfproto meta tag comes before the protocol comparison in expressions
 				if nfproto {
 					if compare.Data[0] == byte(nftables.TableFamilyIPv4) {
 						protocol = "ipv4"

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -10,12 +10,20 @@ import (
 	"fmt"
 
 	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
 )
 
 // RuleTarget represents a location to manipulate nftables rules
 type RuleTarget struct {
 	table *nftables.Table
 	chain *nftables.Chain
+}
+
+type RuleUsageCounter struct {
+	protocol string
+	verdict  string
+	bytes    int64
+	packets  int64
 }
 
 // Create a new location to manipulate nftables rules
@@ -124,6 +132,63 @@ func (r *RuleTarget) Update(c *nftables.Conn, rules []RuleData) (bool, int, int,
 // Get the nftables table and chain associated with this RuleTarget
 func (r *RuleTarget) GetTableAndChain() (*nftables.Table, *nftables.Chain) {
 	return r.table, r.chain
+}
+
+func (r *RuleTarget) Get(c *nftables.Conn) ([]*nftables.Rule, error) {
+	return c.GetRules(r.table, r.chain)
+}
+
+func (r *RuleTarget) GetRuleUsageCounters(c *nftables.Conn) ([]RuleUsageCounter, error) {
+	rules, err := r.Get(c)
+
+	if err != nil {
+		return nil, err
+	}
+
+	usageCounters := make([]RuleUsageCounter, len(rules))
+	for i, rule := range rules {
+		verdict := "accept"
+		protocol := ""
+		nfproto := false
+		var bytes, packets int64
+
+		for _, ex := range rule.Exprs {
+			if meta, ok := ex.(*expr.Meta); ok {
+				nfproto = meta.Key == expr.MetaKeyNFPROTO
+			}
+
+			if compare, ok := ex.(*expr.Cmp); ok {
+				if nfproto {
+					if compare.Data[0] == byte(nftables.TableFamilyIPv4) {
+						protocol = "ipv4"
+					} else if compare.Data[0] == byte(nftables.TableFamilyIPv6) {
+						protocol = "ipv6"
+					}
+				}
+			}
+
+			if counter, ok := ex.(*expr.Counter); ok {
+				bytes = int64(counter.Bytes)
+				packets = int64(counter.Packets)
+			}
+
+			if ver, ok := ex.(*expr.Verdict); ok {
+				if ver.Kind == expr.VerdictDrop {
+					verdict = "drop"
+				}
+			}
+		}
+
+		usageCounters[i] = RuleUsageCounter{
+			verdict:  verdict,
+			protocol: protocol,
+			bytes:    bytes,
+			packets:  packets,
+		}
+	}
+
+	return usageCounters, nil
+
 }
 
 func genRuleDelta(existingRules []*nftables.Rule, newRules []RuleData) (add []RuleData, remove []*nftables.Rule) {

--- a/pkg/rule/rule_data.go
+++ b/pkg/rule/rule_data.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"fmt"
+
 	"github.com/google/nftables/expr"
 )
 
@@ -20,4 +22,17 @@ func NewRuleData(id []byte, exprs []expr.Any) RuleData {
 		Expressions: exprs,
 		ID:          id,
 	}
+}
+
+func (d RuleData) getCounters() (bytes *int64, packets *int64, error error) {
+	for _, ex := range d.Expressions {
+		switch v := ex.(type) {
+		case *expr.Counter:
+			bytes := int64(v.Bytes)
+			packets := int64(v.Packets)
+			return &bytes, &packets, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("No counter expression found for rule %s", d.ID)
 }

--- a/pkg/rule/rule_data.go
+++ b/pkg/rule/rule_data.go
@@ -24,7 +24,7 @@ func NewRuleData(id []byte, exprs []expr.Any) RuleData {
 	}
 }
 
-func (d RuleData) getCounters() (bytes *int64, packets *int64, error error) {
+func (d RuleData) counters() (bytes *int64, packets *int64, error error) {
 	for _, ex := range d.Expressions {
 		switch v := ex.(type) {
 		case *expr.Counter:

--- a/pkg/rule/rule_data_test.go
+++ b/pkg/rule/rule_data_test.go
@@ -21,3 +21,28 @@ func TestNewRuleData(t *testing.T) {
 	assert.Equal(t, rD.Expressions[0], &expr.Meta{Key: 0xf, SourceRegister: false, Register: 0x1})
 	assert.Equal(t, rD.Expressions[1], &expr.Cmp{Op: 0x0, Register: 0x1, Data: []uint8{0x2}})
 }
+
+func TestGetCounters(t *testing.T) {
+	id := []byte{0xd, 0xe, 0xa, 0xd}
+	bytes := uint64(9000)
+	packets := uint64(1000)
+	expressions := []expr.Any{&expr.Counter{Bytes: bytes, Packets: packets}}
+
+	rd := NewRuleData(id, expressions)
+	resBytes, resPackets, resError := rd.getCounters()
+
+	assert.Nil(t, resError)
+	assert.EqualValues(t, *resBytes, bytes)
+	assert.EqualValues(t, *resPackets, packets)
+}
+
+func TestGetCountersNoExpressions(t *testing.T) {
+	id := []byte{0xd, 0xe, 0xa, 0xd}
+
+	rd := NewRuleData(id, []expr.Any{})
+	resBytes, resPackets, resError := rd.getCounters()
+
+	assert.NotNil(t, resError)
+	assert.Nil(t, resBytes)
+	assert.Nil(t, resPackets)
+}

--- a/pkg/rule/rule_data_test.go
+++ b/pkg/rule/rule_data_test.go
@@ -22,25 +22,25 @@ func TestNewRuleData(t *testing.T) {
 	assert.Equal(t, rD.Expressions[1], &expr.Cmp{Op: 0x0, Register: 0x1, Data: []uint8{0x2}})
 }
 
-func TestGetCounters(t *testing.T) {
+func TestCounters(t *testing.T) {
 	id := []byte{0xd, 0xe, 0xa, 0xd}
 	bytes := uint64(9000)
 	packets := uint64(1000)
 	expressions := []expr.Any{&expr.Counter{Bytes: bytes, Packets: packets}}
 
 	rd := NewRuleData(id, expressions)
-	resBytes, resPackets, resError := rd.getCounters()
+	resBytes, resPackets, resError := rd.counters()
 
 	assert.Nil(t, resError)
 	assert.EqualValues(t, *resBytes, bytes)
 	assert.EqualValues(t, *resPackets, packets)
 }
 
-func TestGetCountersNoExpressions(t *testing.T) {
+func TestCountersNoExpressions(t *testing.T) {
 	id := []byte{0xd, 0xe, 0xa, 0xd}
 
 	rd := NewRuleData(id, []expr.Any{})
-	resBytes, resPackets, resError := rd.getCounters()
+	resBytes, resPackets, resError := rd.counters()
 
 	assert.NotNil(t, resError)
 	assert.Nil(t, resBytes)

--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -154,7 +154,7 @@ func (r *ManagedRules) genTags(additional []string) []string {
 func (r *ManagedRules) emitUsageCounters(ruleData RuleData) {
 	bytes, packets, err := ruleData.getCounters()
 	if err != nil {
-		r.logger.Errorf("error getting rule counter: %v", err)
+		r.logger.Warnf("error getting rule counter: %v", err)
 		return
 	}
 	err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), *bytes, r.genTags([]string{fmt.Sprintf("id:%s", ruleData.ID)}), 1)

--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -102,11 +102,11 @@ func (r *ManagedRules) Start(ctx context.Context) error {
 				r.logger.Warnf("error getting rules for sending usage count metric: %v", err)
 			} else {
 				for _, counter := range ruleUsageCounters {
-					err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), counter.bytes, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
+					err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), counter.bytes, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol), fmt.Sprintf("id:%s", counter.id)}), 1)
 					if err != nil {
 						r.logger.Warnf("error sending fng-agent.bytes metric: %v", err)
 					}
-					err = r.metrics.Count(m.Prefix("fwng-agent.packets"), counter.packets, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
+					err = r.metrics.Count(m.Prefix("fwng-agent.packets"), counter.packets, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol), fmt.Sprintf("id:%s", counter.id)}), 1)
 					if err != nil {
 						r.logger.Warnf("error sending fng-agent.packets metric: %v", err)
 					}

--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -152,7 +152,7 @@ func (r *ManagedRules) genTags(additional []string) []string {
 }
 
 func (r *ManagedRules) emitUsageCounters(ruleData RuleData) {
-	bytes, packets, err := ruleData.getCounters()
+	bytes, packets, err := ruleData.counters()
 	if err != nil {
 		r.logger.Warnf("error getting rule counter: %v", err)
 		return

--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -102,8 +102,14 @@ func (r *ManagedRules) Start(ctx context.Context) error {
 				r.logger.Warnf("error getting rules for sending usage count metric: %v", err)
 			} else {
 				for _, counter := range ruleUsageCounters {
-					r.metrics.Count(m.Prefix("fwng-agent.bytes"), counter.bytes, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
-					r.metrics.Count(m.Prefix("fwng-agent.packets"), counter.packets, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
+					err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), counter.bytes, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
+					if err != nil {
+						r.logger.Warnf("error sending fng-agent.bytes metric: %v", err)
+					}
+					err = r.metrics.Count(m.Prefix("fwng-agent.packets"), counter.packets, r.genTags([]string{fmt.Sprintf("verdict:%s", counter.verdict), fmt.Sprintf("protocol:%s", counter.protocol)}), 1)
+					if err != nil {
+						r.logger.Warnf("error sending fng-agent.packets metric: %v", err)
+					}
 				}
 			}
 


### PR DESCRIPTION
This evaluates in the rule_manager how much a rule has been seen since it last reset and emits a counter for that value in 
each packets and bytes. The rule's ID is used as a tag on the counter. 