### PR TITLE
Emit counter metrics tracking nftables set usage

### DIFF
--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -188,6 +188,7 @@ func (s *Set) GetSet() *nftables.Set {
 	return s.set
 }
 
+// Gets a set's SetData with associated counters
 func (s *Set) getCountedSetData(c *nftables.Conn) ([]countedSetData, error) {
 	elements, err := c.GetSetElements(s.set)
 	if err != nil {

--- a/pkg/set/set_data.go
+++ b/pkg/set/set_data.go
@@ -297,6 +297,14 @@ func AddressBytesToSetData(start []byte, end []byte) (SetData, error) {
 
 // Convert start and end port bytes to SetData type
 func PortBytesToSetData(start []byte, end []byte) (SetData, error) {
+	if len(start) != 2 {
+		return SetData{}, fmt.Errorf("invalid byte array for port: %+v", start)
+	}
+
+	if len(end) != 2 {
+		return SetData{}, fmt.Errorf("invalid byte array for port: %+v", end)
+	}
+
 	startPort := binaryutil.BigEndian.Uint16(start)
 	endPortExcl := binaryutil.BigEndian.Uint16(end)
 	endPort := endPortExcl - 1

--- a/pkg/set/set_data.go
+++ b/pkg/set/set_data.go
@@ -19,6 +19,12 @@ type SetData struct {
 	Prefix            netip.Prefix
 }
 
+type countedSetData struct {
+	setData SetData
+	packets int64
+	bytes   int64
+}
+
 // Convert a string address to the SetData type
 func AddressStringToSetData(addressString string) (SetData, error) {
 	address, err := netip.ParseAddr(addressString)

--- a/pkg/set/set_data_test.go
+++ b/pkg/set/set_data_test.go
@@ -307,6 +307,18 @@ func TestGoodSingleAddressBytes(t *testing.T) {
 	assert.Equal(t, parsed, res.Address)
 }
 
+func TestGoodPrefixAddressBytes(t *testing.T) {
+	start := []byte{203, 0, 113, 100}
+	end := []byte{203, 0, 113, 104}
+
+	parsed := netip.MustParsePrefix("203.0.113.100/30")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, parsed, res.Prefix)
+
+}
+
 func TestGoodSingleAddressBytesV6(t *testing.T) {
 	start := []byte{0x20, 0x01, 0xdb, 0x80, 0x85, 0xa3, 0x00, 0x01, 0x00, 0x01, 0x8a, 0x2e, 0x13, 0x70, 0x73, 0x34}
 	end := []byte{0x20, 0x01, 0xdb, 0x80, 0x85, 0xa3, 0x00, 0x01, 0x00, 0x01, 0x8a, 0x2e, 0x13, 0x70, 0x73, 0x35}
@@ -318,18 +330,16 @@ func TestGoodSingleAddressBytesV6(t *testing.T) {
 	assert.Equal(t, parsed, res.Address)
 }
 
-func TestGoodPrefixBytes(t *testing.T) {
-	start := []byte{203, 0, 113, 100}
-	end := []byte{203, 0, 113, 104}
+func TestBadStartPortBytes(t *testing.T) {
+	start := []byte{}
+	end := []byte{3, 232}
 
-	parsed := netip.MustParsePrefix("203.0.113.100/30")
-
-	res, err := AddressBytesToSetData(start, end)
-	assert.Nil(t, err)
-	assert.Equal(t, parsed, res.Prefix)
+	res, err := PortBytesToSetData(start, end)
+	assert.Error(t, err)
+	assert.Equal(t, SetData{}, res)
 }
 
-func TestBadPortBytes(t *testing.T) {
+func TestBadEndPortBytes(t *testing.T) {
 	start := []byte{3, 232}
 	end := []byte{}
 

--- a/pkg/set/set_data_test.go
+++ b/pkg/set/set_data_test.go
@@ -264,3 +264,67 @@ func TestGoodNetipAddrPortsV4(t *testing.T) {
 	assert.Equal(t, addrs[0].Address, parsed.Addr())
 	assert.Equal(t, ports[0].Port, parsed.Port())
 }
+
+func TestBadStartAddressBytes(t *testing.T) {
+	start := []byte("bad")
+	end := []byte("203.0.113.100")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Error(t, err)
+	assert.Equal(t, []SetData{}, res)
+}
+
+func TestBadEndAddressBytes(t *testing.T) {
+	start := []byte("203.0.113.100")
+	end := []byte("bad")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Error(t, err)
+	assert.Equal(t, []SetData{}, res)
+}
+
+func TestGoodRangeAddressBytes(t *testing.T) {
+	start := []byte{198, 51, 100, 1}
+	end := []byte{198, 51, 100, 101} // end range is exclusive
+
+	parsedOne := netip.MustParseAddr("198.51.100.1")
+	parsedTwo := netip.MustParseAddr("198.51.100.100")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, parsedOne, res.AddressRangeStart)
+	assert.Equal(t, parsedTwo, res.AddressRangeEnd)
+}
+
+func TestGoodSingleAddressBytes(t *testing.T) {
+	start := []byte{198, 51, 100, 1}
+	end := []byte{198, 51, 100, 2} // end range is exclusive
+
+	parsed := netip.MustParseAddr("198.51.100.1")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, parsed, res.Address)
+}
+
+func TestGoodSingleAddressBytesV6(t *testing.T) {
+	start := []byte{0x20, 0x01, 0xdb, 0x80, 0x85, 0xa3, 0x00, 0x01, 0x00, 0x01, 0x8a, 0x2e, 0x13, 0x70, 0x73, 0x34}
+	end := []byte{0x20, 0x01, 0xdb, 0x80, 0x85, 0xa3, 0x00, 0x01, 0x00, 0x01, 0x8a, 0x2e, 0x13, 0x70, 0x73, 0x35}
+
+	parsed := netip.MustParseAddr("2001:db80:85a3:1:1:8a2e:1370:7334")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, parsed, res.Address)
+}
+
+func TestGoodPrefixBytes(t *testing.T) {
+	start := []byte{203, 0, 113, 100}
+	end := []byte{203, 0, 113, 104}
+
+	parsed := netip.MustParsePrefix("203.0.113.100/30")
+
+	res, err := AddressBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, parsed, res.Prefix)
+}

--- a/pkg/set/set_data_test.go
+++ b/pkg/set/set_data_test.go
@@ -266,21 +266,21 @@ func TestGoodNetipAddrPortsV4(t *testing.T) {
 }
 
 func TestBadStartAddressBytes(t *testing.T) {
-	start := []byte("bad")
-	end := []byte("203.0.113.100")
+	start := []byte{}
+	end := []byte{203, 0, 113, 100}
 
 	res, err := AddressBytesToSetData(start, end)
 	assert.Error(t, err)
-	assert.Equal(t, []SetData{}, res)
+	assert.Equal(t, SetData{}, res)
 }
 
 func TestBadEndAddressBytes(t *testing.T) {
-	start := []byte("203.0.113.100")
-	end := []byte("bad")
+	start := []byte{203, 0, 113, 100}
+	end := []byte{}
 
 	res, err := AddressBytesToSetData(start, end)
 	assert.Error(t, err)
-	assert.Equal(t, []SetData{}, res)
+	assert.Equal(t, SetData{}, res)
 }
 
 func TestGoodRangeAddressBytes(t *testing.T) {
@@ -327,4 +327,31 @@ func TestGoodPrefixBytes(t *testing.T) {
 	res, err := AddressBytesToSetData(start, end)
 	assert.Nil(t, err)
 	assert.Equal(t, parsed, res.Prefix)
+}
+
+func TestBadPortBytes(t *testing.T) {
+	start := []byte{3, 232}
+	end := []byte{}
+
+	res, err := PortBytesToSetData(start, end)
+	assert.Error(t, err)
+	assert.Equal(t, SetData{}, res)
+}
+
+func TestGoodPortBytes(t *testing.T) {
+	start := []byte{3, 232}
+	end := []byte{3, 233}
+
+	res, err := PortBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, SetData{Port: 1000}, res)
+}
+
+func TestGoodPortRangeBytes(t *testing.T) {
+	start := []byte{3, 232}
+	end := []byte{3, 234}
+
+	res, err := PortBytesToSetData(start, end)
+	assert.Nil(t, err)
+	assert.Equal(t, SetData{PortRangeStart: 1000, PortRangeEnd: 1001}, res)
 }

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ngrok/firewall_toolkit/pkg/logger"
 	m "github.com/ngrok/firewall_toolkit/pkg/metrics"
+	"github.com/ngrok/firewall_toolkit/pkg/utils"
 )
 
 type SetUpdateFunc func() ([]SetData, error)
@@ -150,15 +151,15 @@ func (s *ManagedSet) genTags(additional []string) []string {
 func (s *ManagedSet) emitUsageCounters(setDataList []countedSetData) {
 	for _, setData := range setDataList {
 		var tags []string
-		if setData.setData.Port > 0 {
+		if err := utils.ValidatePort(setData.setData.Port); err != nil {
 			tags = []string{fmt.Sprintf("range-start:%v", setData.setData.Port)}
-		} else if setData.setData.PortRangeStart > 0 {
+		} else if err := utils.ValidatePortRange(setData.setData.PortRangeStart, setData.setData.PortRangeEnd); err != nil {
 			tags = []string{fmt.Sprintf("range-start:%v", setData.setData.PortRangeStart), fmt.Sprintf("range-end:%v", setData.setData.PortRangeEnd)}
-		} else if setData.setData.Prefix.IsValid() {
+		} else if err := utils.ValidatePrefix(setData.setData.Prefix); err != nil {
 			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.Prefix)}
-		} else if setData.setData.Address.IsValid() {
+		} else if err := utils.ValidateAddress(setData.setData.Address); err != nil {
 			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.Address)}
-		} else if setData.setData.AddressRangeStart.IsValid() {
+		} else if err := utils.ValidateAddressRange(setData.setData.AddressRangeStart, setData.setData.AddressRangeEnd); err != nil {
 			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.AddressRangeStart), fmt.Sprintf("range-end:%s", setData.setData.AddressRangeEnd)}
 		} else {
 			s.logger.Warnf("invalid set data encountered while emitting counter metrics: %+v", setData.setData)

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -149,28 +149,28 @@ func (s *ManagedSet) genTags(additional []string) []string {
 }
 
 func (s *ManagedSet) emitUsageCounters(setDataList []countedSetData) {
-	for _, setData := range setDataList {
+	for _, d := range setDataList {
 		var tags []string
-		if err := utils.ValidatePort(setData.setData.Port); err != nil {
-			tags = []string{fmt.Sprintf("range-start:%v", setData.setData.Port)}
-		} else if err := utils.ValidatePortRange(setData.setData.PortRangeStart, setData.setData.PortRangeEnd); err != nil {
-			tags = []string{fmt.Sprintf("range-start:%v", setData.setData.PortRangeStart), fmt.Sprintf("range-end:%v", setData.setData.PortRangeEnd)}
-		} else if err := utils.ValidatePrefix(setData.setData.Prefix); err != nil {
-			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.Prefix)}
-		} else if err := utils.ValidateAddress(setData.setData.Address); err != nil {
-			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.Address)}
-		} else if err := utils.ValidateAddressRange(setData.setData.AddressRangeStart, setData.setData.AddressRangeEnd); err != nil {
-			tags = []string{fmt.Sprintf("range-start:%s", setData.setData.AddressRangeStart), fmt.Sprintf("range-end:%s", setData.setData.AddressRangeEnd)}
+		if err := utils.ValidatePort(d.setData.Port); err != nil {
+			tags = []string{fmt.Sprintf("startip_endip:%v", d.setData.Port)}
+		} else if err := utils.ValidatePortRange(d.setData.PortRangeStart, d.setData.PortRangeEnd); err != nil {
+			tags = []string{fmt.Sprintf("startip_endip:%v-%v", d.setData.PortRangeStart, d.setData.PortRangeEnd)}
+		} else if err := utils.ValidatePrefix(d.setData.Prefix); err != nil {
+			tags = []string{fmt.Sprintf("startip_endip:%s", d.setData.Prefix)}
+		} else if err := utils.ValidateAddress(d.setData.Address); err != nil {
+			tags = []string{fmt.Sprintf("startip_endip:%s", d.setData.Address)}
+		} else if err := utils.ValidateAddressRange(d.setData.AddressRangeStart, d.setData.AddressRangeEnd); err != nil {
+			tags = []string{fmt.Sprintf("startip_endip:%s-%s", d.setData.AddressRangeStart, d.setData.AddressRangeEnd)}
 		} else {
-			s.logger.Warnf("invalid set data encountered while emitting counter metrics: %+v", setData.setData)
+			s.logger.Warnf("invalid set data encountered while emitting counter metrics: %+v", d.setData)
 			continue
 		}
 
-		err := s.metrics.Count(m.Prefix("fwng-agent.bytes"), setData.bytes, s.genTags(tags), 1)
+		err := s.metrics.Count(m.Prefix("fwng-agent.bytes"), d.bytes, s.genTags(tags), 1)
 		if err != nil {
 			s.logger.Warnf("error sending fwng-agent.bytes metric: %v", err)
 		}
-		err = s.metrics.Count(m.Prefix("fwng-agent.packets"), setData.packets, s.genTags(tags), 1)
+		err = s.metrics.Count(m.Prefix("fwng-agent.packets"), d.packets, s.genTags(tags), 1)
 		if err != nil {
 			s.logger.Warnf("error sending fwng-agent.packets metric: %v", err)
 		}

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -151,17 +151,18 @@ func (s *ManagedSet) genTags(additional []string) []string {
 func (s *ManagedSet) emitUsageCounters(setDataList []countedSetData) {
 	for _, d := range setDataList {
 		var tags []string
-		if err := utils.ValidatePort(d.setData.Port); err != nil {
+		switch {
+		case utils.ValidatePort(d.setData.Port) != nil:
 			tags = []string{fmt.Sprintf("startip_endip:%v", d.setData.Port)}
-		} else if err := utils.ValidatePortRange(d.setData.PortRangeStart, d.setData.PortRangeEnd); err != nil {
+		case utils.ValidatePortRange(d.setData.PortRangeStart, d.setData.PortRangeEnd) != nil:
 			tags = []string{fmt.Sprintf("startip_endip:%v-%v", d.setData.PortRangeStart, d.setData.PortRangeEnd)}
-		} else if err := utils.ValidatePrefix(d.setData.Prefix); err != nil {
+		case utils.ValidatePrefix(d.setData.Prefix) != nil:
 			tags = []string{fmt.Sprintf("startip_endip:%s", d.setData.Prefix)}
-		} else if err := utils.ValidateAddress(d.setData.Address); err != nil {
+		case utils.ValidateAddress(d.setData.Address) != nil:
 			tags = []string{fmt.Sprintf("startip_endip:%s", d.setData.Address)}
-		} else if err := utils.ValidateAddressRange(d.setData.AddressRangeStart, d.setData.AddressRangeEnd); err != nil {
+		case utils.ValidateAddressRange(d.setData.AddressRangeStart, d.setData.AddressRangeEnd) != nil:
 			tags = []string{fmt.Sprintf("startip_endip:%s-%s", d.setData.AddressRangeStart, d.setData.AddressRangeEnd)}
-		} else {
+		default:
 			s.logger.Warnf("invalid set data encountered while emitting counter metrics: %+v", d.setData)
 			continue
 		}


### PR DESCRIPTION
This evaluates in the set_manager how much each element of a set has been seen since it last reset and emits a counter for that value in each packets and bytes. When applicable, the Address/Address Range/Prefix or Port/Port Range is used as a tag on the counter. 