### PR TITLE
use %x for the byte slice string formatting

### DIFF
--- a/pkg/rule/rule_manager.go
+++ b/pkg/rule/rule_manager.go
@@ -157,11 +157,11 @@ func (r *ManagedRules) emitUsageCounters(ruleData RuleData) {
 		r.logger.Warnf("error getting rule counter: %v", err)
 		return
 	}
-	err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), *bytes, r.genTags([]string{fmt.Sprintf("id:%v", ruleData.ID)}), 1)
+	err = r.metrics.Count(m.Prefix("fwng-agent.bytes"), *bytes, r.genTags([]string{fmt.Sprintf("id:%x", ruleData.ID)}), 1)
 	if err != nil {
 		r.logger.Warnf("error sending fwng-agent.bytes metric: %v", err)
 	}
-	err = r.metrics.Count(m.Prefix("fwng-agent.packets"), *packets, r.genTags([]string{fmt.Sprintf("id:%v", ruleData.ID)}), 1)
+	err = r.metrics.Count(m.Prefix("fwng-agent.packets"), *packets, r.genTags([]string{fmt.Sprintf("id:%x", ruleData.ID)}), 1)
 	if err != nil {
 		r.logger.Warnf("error sending fwng-agent.packets metric: %v", err)
 	}


### PR DESCRIPTION
We are currently seeing user ids with values like `[4]` be displayed as `_4`. Using `%x` should see that instead display as `04`