### PR TITLE
clear sets on error option

### DIFF
--- a/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets.go
+++ b/cmd/fwtk-input-filter-sets/fwtk-input-filter-sets.go
@@ -173,6 +173,7 @@ func main() {
 			RefreshInterval,
 			logger.Default,
 			nil,
+			true,
 		)
 
 		if err != nil {
@@ -185,6 +186,7 @@ func main() {
 			RefreshInterval,
 			logger.Default,
 			nil,
+			true,
 		)
 
 		if err != nil {
@@ -197,6 +199,7 @@ func main() {
 			RefreshInterval,
 			logger.Default,
 			nil,
+			true,
 		)
 
 		if err != nil {

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -116,6 +116,7 @@ func (s *Set) UpdateElements(c *nftables.Conn, newSetData []SetData) (bool, int,
 	// If we haven't initialized CurrentSetData, don't need
 	// the update logic, can just add everything
 	if s.currentSetData == nil {
+		s.mu.Unlock()
 		return true, len(newSetData), 0, s.ClearAndAddElements(c, newSetData)
 	}
 
@@ -162,6 +163,9 @@ func (s *Set) UpdateElements(c *nftables.Conn, newSetData []SetData) (bool, int,
 
 // Remove all elements from the set and then add a list of elements
 func (s *Set) ClearAndAddElements(c *nftables.Conn, newSetData []SetData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	c.FlushSet(s.set)
 	// Clear/Initialize existing map
 	s.currentSetData = make(map[SetData]struct{})

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -158,6 +158,11 @@ func (s *ManagedSet) genTags(additional []string) []string {
 }
 
 func (s *ManagedSet) emitUsageCounters(setDataList []countedSetData) {
+	err := s.metrics.Count(m.Prefix("fwng-agent.set_count_diff"), int64(len(setDataList)-len(s.set.currentSetData)), s.genTags([]string{}), 1)
+	if err != nil {
+		s.logger.Warnf("error sending fwng-agent.set_count_diff metric: %v", err)
+	}
+
 	for _, d := range setDataList {
 		var tags []string
 		switch {

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -100,10 +100,6 @@ func (s *ManagedSet) Start(ctx context.Context) error {
 					s.logger.Warnf("error sending manager_loop_update_data metric: %v", err)
 				}
 
-				if s.clearOnError {
-					s.set.currentSetData = nil
-				}
-
 				continue
 			}
 			err = s.metrics.Count(m.Prefix("manager_loop_update_data"), 1, s.genTags([]string{"success:true"}), 1)
@@ -124,6 +120,7 @@ func (s *ManagedSet) Start(ctx context.Context) error {
 				}
 
 				if s.clearOnError {
+					s.logger.Warnf("clear on error for table/set %v/%v, next manager run starts from scratch")
 					s.set.currentSetData = nil
 				}
 

--- a/pkg/set/set_manager.go
+++ b/pkg/set/set_manager.go
@@ -120,7 +120,7 @@ func (s *ManagedSet) Start(ctx context.Context) error {
 				}
 
 				if s.clearOnError {
-					s.logger.Warnf("clear on error for table/set %v/%v, next manager run starts from scratch")
+					s.logger.Warnf("clear on error for table/set %v/%v, next manager run starts from scratch", s.set.set.Table.Name, s.set.set.Name)
 					s.set.currentSetData = nil
 				}
 

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -189,7 +189,7 @@ func TestClearAndAddElements(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{set: nfSet, &sync.Mutex{}}
+	set := Set{set: nfSet, mu: &sync.Mutex{}}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)
@@ -222,7 +222,7 @@ func TestUpdateSetBadType(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{set: nfSet, &sync.Mutex{}}
+	set := Set{set: nfSet, mu: &sync.Mutex{}}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -189,7 +189,7 @@ func TestClearAndAddElements(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{set: nfSet}
+	set := Set{set: nfSet, &sync.Mutex{}}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)
@@ -222,7 +222,7 @@ func TestUpdateSetBadType(t *testing.T) {
 		Interval: true,
 		Counter:  true,
 	}
-	set := Set{set: nfSet}
+	set := Set{set: nfSet, &sync.Mutex{}}
 
 	setData, err := AddressStringToSetData("192.0.2.1")
 	assert.Nil(t, err)


### PR DESCRIPTION
This PR introduces "clear on error" to the set manager. When enabled if the nftables flush that happens at the end of the set manager run fails it will set the current set data struct to `nil`. This will cause the subsequent manager run to perform a `ClearAndAddElements` instead of the normal `UpdateElements`.

This PR also adds a new metric `set_count_diff` to detect differentials between what state the manager has with the state that nftables has for a given set. As well as adds locking to `ClearAndAddElements`.